### PR TITLE
ci: auto-regenerate pnpm-lock.yaml on dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -1,0 +1,57 @@
+name: Dependabot Lockfile Sync
+
+on:
+  pull_request:
+    paths:
+      - 'package.json'
+      - 'sdks/**/package.json'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: dependabot-lockfile-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sync-lockfile:
+    name: Regenerate pnpm-lock.yaml
+    if: github.actor == 'dependabot[bot]'
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.RELEASE_PAT }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Regenerate lockfile
+        run: pnpm install --no-frozen-lockfile --ignore-scripts
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet pnpm-lock.yaml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pnpm-lock.yaml
+          git commit -m "chore: regenerate pnpm-lock.yaml for dependabot"
+          git push


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/dependabot-lockfile.yml` to fix dependabot PRs that fail with `ERR_PNPM_OUTDATED_LOCKFILE`.
- Dependabot bumps `sdks/typescript/package.json` but does not refresh the root `pnpm-lock.yaml`. CI then fails on `pnpm install --frozen-lockfile`.
- This workflow runs on dependabot-authored PRs that touch any `package.json`, regenerates `pnpm-lock.yaml`, and pushes the diff back to the PR branch.

## Design
- Trigger: `pull_request` filtered on `package.json` paths.
- Guard: `if: github.actor == 'dependabot[bot]'` keeps it from running on human PRs and prevents re-trigger on the bot's own auto-commit.
- Auth: uses `RELEASE_PAT` because GitHub gives dependabot-triggered workflows a read-only `GITHUB_TOKEN`.
- Safety: `pnpm install --no-frozen-lockfile --ignore-scripts` so postinstall scripts from a bumped dep do not run during lockfile regen.
- Concurrency group on `github.ref` cancels stale runs if dependabot updates the same PR.
- SHA-pinned actions, `blacksmith-2vcpu-ubuntu-2404`, bot committer email matching the rest of the workflows.

## Test plan
- [ ] Merge this PR.
- [ ] Re-trigger dependabot PR #15 (hono bump) by commenting `@dependabot rebase` and confirm CI passes after the lockfile sync commit lands.
- [ ] Re-trigger dependabot PR #16 (next bump) the same way.
- [ ] Confirm the workflow does not loop on its own auto-commits (check Actions tab — only one run per dependabot push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)