### PR TITLE
chore: add Dependabot lockfile sync workflow to automate pnpm-lock.ya…

### DIFF
--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -1,0 +1,57 @@
+name: Dependabot Lockfile Sync
+
+on:
+  pull_request:
+    paths:
+      - "package.json"
+      - "sdks/**/package.json"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: dependabot-lockfile-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sync-lockfile:
+    name: Regenerate pnpm-lock.yaml
+    if: github.actor == 'dependabot[bot]'
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.RELEASE_PAT }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Regenerate lockfile
+        run: pnpm install --no-frozen-lockfile --ignore-scripts
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet pnpm-lock.yaml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pnpm-lock.yaml
+          git commit -m "chore: regenerate pnpm-lock.yaml for dependabot"
+          git push


### PR DESCRIPTION
…ml regeneration

## Summary

<!-- What changed and why? Keep it to 1-3 sentences. -->

## Changes

-

## Test plan

- [ ] Tests pass locally (`pnpm nx run sdk-typescript:test`)
- [ ] Lint passes (`pnpm nx run sdk-typescript:lint`)
- [ ] Build succeeds (`pnpm nx run sdk-typescript:build`)
- [ ]

## Related issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
